### PR TITLE
Add CI workflow for linting and building

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,56 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Run lint
+        run: npm run lint
+
+      - name: Build
+        run: npm run build
+
+      - name: Create tag
+        id: create_tag
+        run: |
+          TAG=$(date +'%Y%m%d%H%M')
+          echo "TAG=$TAG" >> $GITHUB_ENV
+
+      - name: Create release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ env.TAG }}
+          release_name: Release ${{ env.TAG }}
+          draft: false
+          prerelease: false
+
+      - name: Compress build folder
+        run: zip -r build.zip build
+
+      - name: Upload build.zip to release
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./build.zip
+          asset_name: build.zip
+          asset_content_type: application/zip


### PR DESCRIPTION
Add a new GitHub Actions workflow file to define the CI pipeline.

* **Checkout and Install Dependencies**
  - Checkout code using `actions/checkout@v2`
  - Install dependencies with `npm install`

* **Lint and Build**
  - Run lint with `npm run lint`
  - Build with `npm run build`

* **Release Process**
  - Create a tag based on the current date and time
  - Create a new release based on the tag using `actions/create-release@v1`
  - Compress the "build" folder into "build.zip"
  - Upload "build.zip" to the release using `actions/upload-release-asset@v1`

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/jerryrox/github-test-project/pull/3?shareId=0017d99f-cbd3-47e8-99e6-8bb54d851382).